### PR TITLE
[Fix] Prod 서버 Milvus Host 버그 수정

### DIFF
--- a/.github/workflows/dev-fastapi-ecr.yml
+++ b/.github/workflows/dev-fastapi-ecr.yml
@@ -70,5 +70,5 @@ jobs:
               docker pull ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
               docker stop $CONTAINER_NAME || true
               docker rm $CONTAINER_NAME || true
-              docker run -d --name $CONTAINER_NAME -p 8000:8000 --restart always ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
+              docker run -d --name $CONTAINER_NAME -p 8000:8000 --env-file .env --restart always ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
             EOSSH

--- a/.github/workflows/prod-fastapi-ecr.yml
+++ b/.github/workflows/prod-fastapi-ecr.yml
@@ -70,5 +70,5 @@ jobs:
               docker pull ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
               docker stop $CONTAINER_NAME || true
               docker rm $CONTAINER_NAME || true
-              docker run -d --name $CONTAINER_NAME -p 8000:8000 --restart always ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
+              docker run -d --name $CONTAINER_NAME -p 8000:8000 --env-file .env --restart always ${{secrets.ECR_REGISTRY}}/$ECR_REPOSITORY:${{ github.sha }}
             EOSSH

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from starlette.responses import StreamingResponse, JSONResponse
 from ColorRemover import ColorRemover
 import ImageFunctions as ImageManager
 import logging
-
+import os
 from openai import OpenAI
 from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
 
@@ -24,6 +24,9 @@ s3_client = boto3.client( "s3",
                           region_name="ap-northeast-2")
 ssm_client = boto3.client('ssm',
                           region_name='ap-northeast-2')
+SERVER = os.getenv('SERVER')
+logger.info(f"* log >> 환경변수 SERVER: {SERVER}로 받아왔습니다.")
+
 # s3 버킷 연결
 try:
     response = s3_client.list_buckets()
@@ -181,11 +184,11 @@ async def ocr(problem_url: str):
         logger.info("Completed Download & Sending Requests... '%s'", s3_key)
 
         clova_api_url = ssm_client.get_parameter(
-            Name='/ono/new_dev/fastapi/CLOVA_API_URL',
+            Name=f'/ono/{SERVER}/fastapi/CLOVA_API_URL',
             WithDecryption=False
         )['Parameter']['Value']
         clova_secret_key = ssm_client.get_parameter(
-            Name='/ono/new_dev/fastapi/CLOVA_SECRET_KEY',
+            Name=f'/ono/{SERVER}/fastapi/CLOVA_SECRET_KEY',
             WithDecryption=False
         )['Parameter']['Value']
 
@@ -248,14 +251,14 @@ async def upload_curriculum_txt(upload_file: UploadFile = File(...)):
 
 # OpenAI 연결
 openai_secret_key = ssm_client.get_parameter(
-    Name='/ono/new_dev/fastapi/OPENAI_API_KEY',
+    Name=f'/ono/{SERVER}/fastapi/OPENAI_API_KEY',
     WithDecryption=False
 )['Parameter']['Value']
 openai_client = OpenAI(api_key=openai_secret_key)
 
 # Mivlus DB 연결
 MILVUS_HOST = ssm_client.get_parameter(
-    Name='/ono/new_dev/fastapi/MILVUS_HOST_NAME',
+    Name=f'/ono/{SERVER}/fastapi/MILVUS_HOST_NAME',
     WithDecryption=False
 )['Parameter']['Value']
 MILVUS_PORT = 19530

--- a/app/main.py
+++ b/app/main.py
@@ -24,8 +24,6 @@ s3_client = boto3.client( "s3",
                           region_name="ap-northeast-2")
 ssm_client = boto3.client('ssm',
                           region_name='ap-northeast-2')
-SERVER = os.getenv('SERVER')
-logger.info(f"* log >> 환경변수 SERVER: {SERVER}로 받아왔습니다.")
 
 # s3 버킷 연결
 try:
@@ -184,11 +182,11 @@ async def ocr(problem_url: str):
         logger.info("Completed Download & Sending Requests... '%s'", s3_key)
 
         clova_api_url = ssm_client.get_parameter(
-            Name=f'/ono/{SERVER}/fastapi/CLOVA_API_URL',
+            Name='/ono/fastapi/CLOVA_API_URL',
             WithDecryption=False
         )['Parameter']['Value']
         clova_secret_key = ssm_client.get_parameter(
-            Name=f'/ono/{SERVER}/fastapi/CLOVA_SECRET_KEY',
+            Name='/ono/fastapi/CLOVA_SECRET_KEY',
             WithDecryption=False
         )['Parameter']['Value']
 
@@ -251,12 +249,15 @@ async def upload_curriculum_txt(upload_file: UploadFile = File(...)):
 
 # OpenAI 연결
 openai_secret_key = ssm_client.get_parameter(
-    Name=f'/ono/{SERVER}/fastapi/OPENAI_API_KEY',
+    Name='/ono/fastapi/OPENAI_API_KEY',
     WithDecryption=False
 )['Parameter']['Value']
 openai_client = OpenAI(api_key=openai_secret_key)
 
 # Mivlus DB 연결
+SERVER = os.getenv('SERVER')
+logger.info(f"* log >> 환경변수 SERVER: {SERVER}로 받아왔습니다.")
+
 MILVUS_HOST = ssm_client.get_parameter(
     Name=f'/ono/{SERVER}/fastapi/MILVUS_HOST_NAME',
     WithDecryption=False


### PR DESCRIPTION
### PR 타입
✅  버그 수정
✅  CI/CD 워크플로우 업데이트
<br>

### 반영 브랜치
dev ➡️  main
<br>

### 작업 사항
#### 📝`서버 간 공유 Key는 저장 Path 단일화`
외부 API 호출은 동일 key를 사용하므로 저장된 클라우드 path를 단일화하였습니다.
#### 📝 `서버 간 Milvus Host는 저장 Path 구분`
개발 서버와 운영 서버는 서로 다른 host이므로, 이를 환경변수로 가져와서 다른 path에 저장된 값을 가져올 수 있도록 수정했습니다.
#### 📝 `CI/CD 변경`
docker run 시, 서버에 저장된 환경변수 파일 .env를 컨테이너 환경변수에 추가합니다.
<br>

### 테스트 방법
추가된 기능은 아래 방식으로 자유롭게 요청&응답 테스트가 가능합니다.
- Dev/Prod 서버 Postman
- Dev/Prod 서버 Swagger UI
- 깃허브 액션은 assignee 외에는 실행하지 말고, 로그를 확인합니다.
<br>

### 테스트 결과
해당 FastAPI의 모든 엔드포인트에 대해 Dev 서버에서 정상적인 동작함을 확인했습니다.
서버에 기록된 로그를 확인한 결과, 성공했습니다.
깃허브 액션 실행 결과, DEV는 성공, PRD는 실행 예정입니다
