### PR TITLE
[Fix] Vector Search & LLM Prompt 성능 개선

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -456,12 +456,14 @@ async def retrieve(problem_text: str):
 
 @app.get("/analysis/augmentation")
 async def augment(curriculum_context, query):
-    prompt = "너는 공책이야. 내가 준 교육과정 중에 아래 문제와 관련된 교육과정을 골라서 고등학생 한 명에게\
-    이 문제를 왜 틀리거나 헷갈릴 수 있으며, 어떤 개념과 사고과정 등이 필요해 보이는지를 \
-    이 문제의 의도와 핵심을 짚어가되 너무 길지 않게 정리해서 고등학생에게 보여줘.\n"
-    context = f"교과과정은 이렇고 {curriculum_context}"
-    passage = f"문제는 이러해 {query}."
-    augmented_query = prompt + context + passage
+    prompt = ("너는 고등학생의 오답 문제를 통해 약점을 보완해주는 공책이야. \
+              교육과정을 참고해서 오답 문제 핵심 의도를 바탕으로 문제에서 헷갈릴만한 요소, \
+              학생이 놓친 것 같은 중요한 개념을 찾아 그 개념에 대해 4줄 이내로 설명해주고, \
+              그 개념을 적용해서 풀이를 요점에 따라서 짧게(4줄 내외) 작성해줘. \
+              만약 오답 문제와 교과과정이 관련이 없다고 판단되면, 교육과정은 참고하지 않으면 돼. \n\n\n")
+    passage = f"오답 문제 : {query} \n\n\n"
+    context = f"교과과정 : {curriculum_context} \n\n\n"
+    augmented_query = prompt + passage + context
     return augmented_query
 
 @app.get("/analysis/generation")

--- a/app/main.py
+++ b/app/main.py
@@ -422,7 +422,8 @@ async def retrieve(problem_text: str):
         search_params = {
             'metric_type': 'COSINE',
             'params': {
-                'probe': 20
+                'radius': 0.35,
+                'range_filter': 0.9
             },
         }
         dt5 = str(datetime.fromtimestamp(time.time()))
@@ -430,7 +431,7 @@ async def retrieve(problem_text: str):
             data=query_embeddings[0],
             anns_field='content_embedding',
             param=search_params,
-            limit=3,
+            limit=2,
             expr=None,
             output_fields=['content', 'subject_name', 'unit_name', 'main_concept']
         )


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정
- [x] 성능 개선
<br>

### 반영 브랜치
dev ➡️ main
<br>

### 작업 사항
#### 📝`벡터 검색 결과 정확도 필터링`
벡터 검색 결과에 대한 confidency(정확도)의 radius와 range를 설정하여 지정된 정확도 범위 내 결과만을 반환하도록 수정했습니다. 너무 낮은 정확도를 가지는 경우 LLM의 context로 처리할 수 없도록 했습니다.
#### 📝`검색 결과 문서 갯수 감축`
너무 긴 input은 llm의 긴 응답 시간을 초래하므로 문서 개수를 3개에서 2개로 감소시켰습니다.
#### 📝`LLM 프롬프팅`
너무 긴 응답을 하고 있어 가독성을 해치는 문제점을 해소하기 위해서 답변 분량을 제한하였습니다.
<br>

### 테스트 방법
추가된 기능은 아래 방식으로 자유롭게 요청&응답 테스트가 가능합니다.
- Dev/Prod 서버 Postman
- Dev/Prod 서버 Swagger UI
- 깃허브 액션은 실행하지 말고, 로그를 확인합니다.

### 테스트 결과
답변 시간은 30%정도 단축되었으며, 아래와 같이 향상된 가독성을 보였습니다.
|문항 이미지|변경 전|변경 후|
|:--:|:--:|:--:|
|![image](https://github.com/user-attachments/assets/b8b0182b-ef07-43d9-8128-0a70881fe867)| <img width="726" alt="image" src="https://github.com/user-attachments/assets/8b775b46-6c67-4734-9bba-f3f84d087ab2">|<img width="720" alt="image" src="https://github.com/user-attachments/assets/a93cfb7e-bef9-498e-9790-f04dfa5fc2f3">|