### PR TITLE
[Feat & FIx] 필기 인식 강도 기술 추가 & 필기 제거 API 변경

### DIFF
--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -57,15 +57,14 @@ class ColorRemover:
             temp_mask = cv2.inRange(image_hsv, lower_bound, upper_bound)
             self.masks = cv2.bitwise_or(self.masks, temp_mask)
 
-        # Dilation 적용
-        '''kernel = np.ones((3,3), np.uint8)
-        if self.masks is not None:
-            self.masks = cv2.dilate(self.masks, kernel, iterations=3)'''
-
         # Opening 적용
-        '''if self.size > 1024 * 1536:
-            kernel = np.ones((1, 1), np.uint8)  # mask 내 노이즈 제거
-            self.masks = cv2.morphologyEx(self.masks, cv2.MORPH_OPEN, kernel)'''
+        '''kernel = np.ones((3, 3), np.uint8)  # mask 내 노이즈 제거
+        self.masks = cv2.morphologyEx(self.masks, cv2.MORPH_OPEN, kernel)'''
+
+        # Dilation 적용
+        '''kernel = np.ones((1, 1), np.uint8)
+        if self.masks is not None:
+            self.masks = cv2.dilate(self.masks, kernel, iterations=2)'''
 
     def inpainting(self, image_rgb):
         if self.masks is not None and isinstance(self.masks, np.ndarray):

--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -17,14 +17,15 @@ def rgb_to_hsv_list(rgb_list):
 
 
 class ColorRemover:
-    def __init__(self, target_rgb_list, tolerance=(30, 150, 150)): # 팀 주정뱅이: 30, 150, 150
+    def __init__(self, target_rgb_list, intensity):  # 팀 주정뱅이: 30, 150, 150
         self.size = 0
         self.height = 0
         self.width = 0
 
         self.target_rgb_list = target_rgb_list
         self.target_hsv_list = None
-        self.tolerance = tolerance
+        self.tolerance = None
+        self.intensity = intensity
 
         self.alpha_channel = None
         self.masks = None
@@ -40,21 +41,47 @@ class ColorRemover:
         image_mask = image_rgb.copy()
         image_hsv = cv2.cvtColor(image_mask, cv2.COLOR_BGR2HSV)
 
-        '''lower_bound = np.array([95, 10, 10])  # target_hsv - tolerance
-                    upper_bound = np.array([125, 255, 255])  # target_hsv + tolerance
-                    self.masks = cv2.inRange(image_hsv, lower_bound, upper_bound)'''
-
         self.masks = np.zeros(image_hsv.shape[:2], dtype=np.uint8)
         self.target_hsv_list = rgb_to_hsv_list(self.target_rgb_list)
         for target_hsv in self.target_hsv_list:
-            logging.info("target_hsv: %s, tolerance: %s", target_hsv, self.tolerance)
-            lower_bound = np.array([max(0, target_hsv[0] - self.tolerance[0]),
-                                    max(5, target_hsv[1] - self.tolerance[1]),
-                                    max(5, target_hsv[2] - self.tolerance[2])])
-            upper_bound = np.array([min(179, target_hsv[0] + self.tolerance[0]),
-                                    min(255, target_hsv[1] + self.tolerance[1]),
-                                    min(255, target_hsv[2] + self.tolerance[2])])
+            circle_mask = None
+            if self.intensity == 0 or (self.intensity == 1 and target_hsv[1] <= 25):  # 샤프 특화
+                self.tolerance = (150, 35, 80)
+                lower_bound = np.array([max(0, target_hsv[0] - self.tolerance[0]),
+                                        max(0, target_hsv[1] - self.tolerance[1]),
+                                        max(50 , target_hsv[2] - self.tolerance[2])])
+                upper_bound = np.array([min(179, target_hsv[0] + self.tolerance[0]),
+                                        min(200, target_hsv[1] + self.tolerance[1]),
+                                        min(150, target_hsv[2] + self.tolerance[2])])
+            elif self.intensity == 2 or (self.intensity == 1 and target_hsv[1] > 25):
+                self.tolerance = (30, 180, 160)  # 튀는 색상펜 특화
+                lower_bound = np.array([max(0, target_hsv[0] - self.tolerance[0]),
+                                        max(20, target_hsv[1] - self.tolerance[1]),
+                                        max(10, target_hsv[2] - self.tolerance[2])])
+                upper_bound = np.array([min(179, target_hsv[0] + self.tolerance[0]),
+                                        min(255, target_hsv[1] + self.tolerance[1]),
+                                        min(255, target_hsv[2] + self.tolerance[2])])
+                lower_hue = target_hsv[0] - self.tolerance[0]
+                upper_hue = target_hsv[0] + self.tolerance[0]
+                # 빨간색 순환처리
+                if lower_hue < 0:
+                    circle_lower_bound = lower_bound.copy()
+                    circle_upper_bound = upper_bound.copy()
+                    circle_lower_bound[0] = (target_hsv[0] - self.tolerance[0] + 180) % 180
+                    circle_upper_bound[0] = 179
+                    circle_mask = cv2.inRange(image_hsv, circle_lower_bound, circle_upper_bound)
+                elif upper_hue > 179:
+                    circle_lower_bound = lower_bound.copy()
+                    circle_upper_bound = upper_bound.copy()
+                    circle_lower_bound[0] = 0
+                    circle_upper_bound[0] = (target_hsv[0] + self.tolerance[0] - 180) % 180
+                    circle_mask = cv2.inRange(image_hsv, circle_lower_bound, circle_upper_bound)
+
             temp_mask = cv2.inRange(image_hsv, lower_bound, upper_bound)
+            logging.info("target_hsv: %s, from: %s  to: %s", target_hsv, lower_bound, upper_bound)
+            if circle_mask is not None:
+                temp_mask = cv2.bitwise_or(temp_mask, circle_mask)
+                logging.info("+ red target_hsv: %s, from: %s  to: %s", target_hsv, circle_lower_bound, circle_upper_bound)
             self.masks = cv2.bitwise_or(self.masks, temp_mask)
 
         # Opening 적용

--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -70,7 +70,7 @@ class ColorRemover:
     def inpainting(self, image_rgb):
         if self.masks is not None and isinstance(self.masks, np.ndarray):
             inpainted_image = image_rgb.copy()
-            inpainted_image = cv2.inpaint(inpainted_image, self.masks, 15, cv2.INPAINT_TELEA)
+            inpainted_image = cv2.inpaint(inpainted_image, self.masks, 10, cv2.INPAINT_TELEA)
             # inpainted_image = cv2.inpaint(inpainted_image, self.masks, 2, cv2.INPAINT_TELEA)
             # inpainted_image[self.masks != 0] = [255, 255, 255]
             return inpainted_image

--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -223,8 +223,8 @@ class ColorRemover:
     def filtering(self, img_rgb):
         """ 이미지의 명암대비 강화 및 밝기 증가"""
 
-        alpha = 1.3  # 대비 계수
-        beta = 1.1  # 밝기 조절이 필요 없는 경우 0
+        alpha = 1.1  # 대비 계수
+        beta = 1.0  # 밝기 조절이 필요 없는 경우 1.0
         enhanced_contrast_image = cv2.convertScaleAbs(img_rgb, alpha=alpha, beta=beta)  # 대비가 강화된 이미지 생성
 
         return enhanced_contrast_image

--- a/app/main.py
+++ b/app/main.py
@@ -76,7 +76,7 @@ async def processColor(request: Request):
     data = await request.json()
     full_url = data['fullUrl']
     colors_list = data['colorsList']
-    tolerance = data.get('tolerance')  # value or None
+    intensity = data.get('intensity')  # value or None
 
     try:
         target_rgb_list = []
@@ -93,10 +93,9 @@ async def processColor(request: Request):
         corrected_img_bytes = ImageManager.correct_rotation(img_bytes, paths['extension'])
         logger.info("Key is : %s and Start processing", s3_key)
 
-        if tolerance is not None:
-            color_remover = ColorRemover(target_rgb_list, tolerance)
-        else:
-            color_remover = ColorRemover(target_rgb_list)
+        if intensity is None:
+            intensity = 1  # default: weak
+        color_remover = ColorRemover(target_rgb_list, intensity)
         img_input_bytes, img_mask_bytes, img_output_bytes = color_remover.process(corrected_img_bytes, paths['extension'])
         logger.info("Finished Processing, and Start Uploading Image")
 


### PR DESCRIPTION
### PR 타입
- [x] 새로운 기능 추가
- [x] 주석 추가/수정
<br>

### 반영 브랜치
dev ➡️ main
<br>

### 작업 사항
#### 📝`새로운 기능: 필기 인식 강도`
무채색의 필기구 (샤프), 색상을 가진 필기구 (유성볼펜, 사인펜 등)에 따라 색상 인식 범위 상한과 하한을 설정하여 보다 정교해진 필기 인식 기능을 확인할 수 있습니다. 
#### 📝`필기 제거 API 요청 body 변경`
필기 제거 API 요청 body에 intensity 요소를 추가했습니다. 0, 1, 2에 따른 값을 넘겨주면 되며, 넘겨주지 않는 경우 기본 1로 설정됩니다.
<br>

### 테스트 방법
추가된 기능은 아래 방식으로 자유롭게 요청 테스트가 가능합니다.
intensity를 1로 설정할 경우 색상펜과 샤프펜슬 모두에 대해 사용가능하므로 권장합니다.
- Dev/Prod 서버 Postman
응답은 기존 방식처럼 이미지 경로를 반환하는 형식을 유지했습니다.

### 테스트 결과
1. 샤프와 인쇄된 글씨를 구분할 수 있는 요소는 오직 밝기입니다. 촬영 기기와 주변 조명에 따라 오차가 발생하긴 하지만 대체적으로 이전보다 잘 작동하며, 혹여 인쇄된 글씨가 약간 흐려지거나 지워지더라도 읽을 수 있을 정도임을 확인했습니다. 샤프 펜슬은 진한 부분을 제외하면 잘 지워짐을 확인할 수 있습니다.
2. 색상펜은 인쇄된 글씨와 색상, 채도, 밝기 세 가지 요소로 구분되기에 색상펜이 너무 어둡거나 강하게 눌러 쓴 경우만 제외하면 잘 작동합니다. 인쇄된 글씨가 함께 인식되어 흐려지는 일은 발생하지 않습니다.
|원본 이미지|샤프 제거|색상펜 제거|
|:--:|:--:|:--:|
|![image](https://github.com/user-attachments/assets/3a66de35-aea6-47c2-bf06-35ff35c18abf)|![image](https://github.com/user-attachments/assets/2c1f4a9e-0afc-4a83-b2c1-1fda7852d624)|![image](https://github.com/user-attachments/assets/8360fa49-b510-4ed1-83c4-d7844cfe18ba)|