### PR TITLE
[Feat&Fix] 필기 제거 강도 옵션 최적화

### DIFF
--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -60,11 +60,10 @@ class ColorRemover:
         for target_hsv in self.target_hsv_list:
             circle_mask = None
             if target_hsv[1] <= 25:  # 색상의 채도가 낮다면 -> 펜슬 간주
-                continue
                 lower_bound = np.array([max(0, target_hsv[0] - self.sharp_tolerance[0]),
                                         max(0, target_hsv[1] - self.sharp_tolerance[1]),
                                         max(lower_min_v, target_hsv[2] - self.sharp_tolerance[2])])
-                upper_bound = np.array([min(179, target_hsv[0] + self.sharp_tolerance[0]),
+                upper_bound = np.array([min(180, target_hsv[0] + self.sharp_tolerance[0]),
                                         min(30, target_hsv[1] + self.sharp_tolerance[1]),
                                         min(150, target_hsv[2] + self.sharp_tolerance[2])])
             else:  # 색상의 채도가 있다면 -> 색상펜 간주
@@ -80,9 +79,9 @@ class ColorRemover:
                     circle_lower_bound = lower_bound.copy()
                     circle_upper_bound = upper_bound.copy()
                     circle_lower_bound[0] = (target_hsv[0] - self.color_tolerance[0] + 180) % 180
-                    circle_upper_bound[0] = 179
+                    circle_upper_bound[0] = 180
                     circle_mask = cv2.inRange(image_hsv, circle_lower_bound, circle_upper_bound)
-                elif upper_hue > 179:
+                elif upper_hue > 180:
                     circle_lower_bound = lower_bound.copy()
                     circle_upper_bound = upper_bound.copy()
                     circle_lower_bound[0] = 0

--- a/app/ColorRemover.py
+++ b/app/ColorRemover.py
@@ -24,7 +24,8 @@ class ColorRemover:
 
         self.target_rgb_list = target_rgb_list
         self.target_hsv_list = None
-        self.tolerance = None
+        self.pencil_tolerance = None
+        self.color_tolerance = None
         self.intensity = intensity
 
         self.alpha_channel = None
@@ -43,38 +44,49 @@ class ColorRemover:
 
         self.masks = np.zeros(image_hsv.shape[:2], dtype=np.uint8)
         self.target_hsv_list = rgb_to_hsv_list(self.target_rgb_list)
+        if self.intensity == 0:  # 강도 약하게
+            self.color_tolerance = (5, 180, 160)  # 튀는 색상펜 특화
+            self.sharp_tolerance = (150, 30, 60)  # 샤프 특화
+            lower_min_v = 50
+        elif self.intensity == 1:  # 강도 중간
+            self.color_tolerance = (15, 180, 160)  # 튀는 색상펜 특화
+            self.sharp_tolerance = (150, 30, 60)  # 샤프 특화
+            lower_min_v = 30
+        else:  # 강도 강하게
+            self.color_tolerance = (30, 180, 160)  # 튀는 색상펜 특화
+            self.sharp_tolerance = (150, 40, 90)  # 샤프 특화
+            lower_min_v = 10
+
         for target_hsv in self.target_hsv_list:
             circle_mask = None
-            if self.intensity == 0 or (self.intensity == 1 and target_hsv[1] <= 25):  # 샤프 특화
-                self.tolerance = (150, 35, 80)
-                lower_bound = np.array([max(0, target_hsv[0] - self.tolerance[0]),
-                                        max(0, target_hsv[1] - self.tolerance[1]),
-                                        max(50 , target_hsv[2] - self.tolerance[2])])
-                upper_bound = np.array([min(179, target_hsv[0] + self.tolerance[0]),
-                                        min(200, target_hsv[1] + self.tolerance[1]),
-                                        min(150, target_hsv[2] + self.tolerance[2])])
-            elif self.intensity == 2 or (self.intensity == 1 and target_hsv[1] > 25):
-                self.tolerance = (30, 180, 160)  # 튀는 색상펜 특화
-                lower_bound = np.array([max(0, target_hsv[0] - self.tolerance[0]),
-                                        max(20, target_hsv[1] - self.tolerance[1]),
-                                        max(10, target_hsv[2] - self.tolerance[2])])
-                upper_bound = np.array([min(179, target_hsv[0] + self.tolerance[0]),
-                                        min(255, target_hsv[1] + self.tolerance[1]),
-                                        min(255, target_hsv[2] + self.tolerance[2])])
-                lower_hue = target_hsv[0] - self.tolerance[0]
-                upper_hue = target_hsv[0] + self.tolerance[0]
-                # 빨간색 순환처리
-                if lower_hue < 0:
+            if target_hsv[1] <= 25:  # 색상의 채도가 낮다면 -> 펜슬 간주
+                continue
+                lower_bound = np.array([max(0, target_hsv[0] - self.sharp_tolerance[0]),
+                                        max(0, target_hsv[1] - self.sharp_tolerance[1]),
+                                        max(lower_min_v, target_hsv[2] - self.sharp_tolerance[2])])
+                upper_bound = np.array([min(179, target_hsv[0] + self.sharp_tolerance[0]),
+                                        min(30, target_hsv[1] + self.sharp_tolerance[1]),
+                                        min(150, target_hsv[2] + self.sharp_tolerance[2])])
+            else:  # 색상의 채도가 있다면 -> 색상펜 간주
+                lower_bound = np.array([max(0, target_hsv[0] - self.color_tolerance[0]),
+                                        max(20, target_hsv[1] - self.color_tolerance[1]),
+                                        max(lower_min_v, target_hsv[2] - self.color_tolerance[2])])
+                upper_bound = np.array([min(180, target_hsv[0] + self.color_tolerance[0]),
+                                        min(255, target_hsv[1] + self.color_tolerance[1]),
+                                        min(255, target_hsv[2] + self.color_tolerance[2])])
+                lower_hue = target_hsv[0] - self.color_tolerance[0]
+                upper_hue = target_hsv[0] + self.color_tolerance[0]
+                if lower_hue < 0:  # 빨간색 순환처리
                     circle_lower_bound = lower_bound.copy()
                     circle_upper_bound = upper_bound.copy()
-                    circle_lower_bound[0] = (target_hsv[0] - self.tolerance[0] + 180) % 180
+                    circle_lower_bound[0] = (target_hsv[0] - self.color_tolerance[0] + 180) % 180
                     circle_upper_bound[0] = 179
                     circle_mask = cv2.inRange(image_hsv, circle_lower_bound, circle_upper_bound)
                 elif upper_hue > 179:
                     circle_lower_bound = lower_bound.copy()
                     circle_upper_bound = upper_bound.copy()
                     circle_lower_bound[0] = 0
-                    circle_upper_bound[0] = (target_hsv[0] + self.tolerance[0] - 180) % 180
+                    circle_upper_bound[0] = (target_hsv[0] + self.color_tolerance[0] - 180) % 180
                     circle_mask = cv2.inRange(image_hsv, circle_lower_bound, circle_upper_bound)
 
             temp_mask = cv2.inRange(image_hsv, lower_bound, upper_bound)


### PR DESCRIPTION
### PR 타입
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
<br>

### 반영 브랜치
dev ➡️ main
<br>

### 작업 사항
#### 📝`강도 옵션 추가`
색상펜과 샤프펜슬의 구분이 아닌 색상펜과 샤프펜슬의 혼합에서의 약하게 지우기, 기본 지우기, 강하게 지우기로 변경함. 그 과정에서 리팩토링이 있었습니다. 요청 및 반환 결과는 이전과 동일!
#### 📝`마스킹 색상 범위 최대값 변경`
누락되는 범위가 없도록 하기 위해, upper bound & lower bound에서의 명도&채도의 상수값 179를 180으로 변경하였습니다.
<br>

### 테스트 방법
기존 방식으로 자유롭게 요청&응답 테스트가 가능합니다.
- Dev/Prod 서버 Postman

### 테스트 결과
|원본 이미지|제거 결과 이미지(강도 1: 빨간 색연필 & 샤프)|
|:--:|:--:|
|![원본](https://github.com/user-attachments/assets/836481a2-aee9-4a9e-95aa-9dc493071c4f)|![RedandSharp_강도1](https://github.com/user-attachments/assets/5cd6f392-767a-45ea-a23d-50f8f2221ac1)|

|강도/필기구|빨간 연필|샤프|
|:--:|:--:|:--:|
|0: 약하게|![Red_강도0](https://github.com/user-attachments/assets/aab6e565-5383-45f7-893d-e5ed0bfa89d2)|![Sharp_강도0](https://github.com/user-attachments/assets/cf633e7f-9ad2-4bc5-b24b-5324ad8cfee7)|
|1: 중간|![Red_강도1](https://github.com/user-attachments/assets/0477751b-d9ee-4b65-a66b-3828e1cd0820)|![Sharp_강도1](https://github.com/user-attachments/assets/d64f75ea-75f8-4e45-8b28-0282677d4b1d)|
|2: 강하게|![Red_강도2](https://github.com/user-attachments/assets/20453389-6f36-4213-ab10-ae7ac8f3b0da)|![Sharp_강도2](https://github.com/user-attachments/assets/c0e7e7a0-120f-4094-96cc-59368f3792ef)|