### PR TITLE
[Feat] AI기반 필기인식 기능

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,11 @@ FROM python:3.12-slim
 LABEL org.opencontainers.image.source="https://github.com/AI-SIP/MVP_CV"
 
 # 필요한 시스템 패키지 먼저 설치
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y git \
     libgl1-mesa-glx \
     libglib2.0-0 \
     gcc \
     python3-dev && \
-    git && \
     rm -rf /var/lib/apt/lists/* \
 
 # 작업 디렉토리 설정

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # 작업 디렉토리 설정
 WORKDIR /test
+RUN mkdir models
 
 # 의존성 파일 복사 및 설치
 COPY ./requirements.txt /test/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     gcc \
     python3-dev && \
-    rm -rf /var/lib/apt/lists/*
+    git && \
+    rm -rf /var/lib/apt/lists/* \
 
 # 작업 디렉토리 설정
 WORKDIR /test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y git \
 
 # 작업 디렉토리 설정
 WORKDIR /test
-RUN mkdir models
 
 # 의존성 파일 복사 및 설치
 COPY ./requirements.txt /test/requirements.txt
@@ -27,4 +26,4 @@ COPY ./app /test/app/
 WORKDIR /test/app
 
 # 컨테이너 실행 시 실행할 명령어
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["bash", "-c", "mkdir -p /test/models && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/app/AIProcessor.py
+++ b/app/AIProcessor.py
@@ -118,7 +118,12 @@ class AIProcessor:
         return masks_np
 
     def inpainting(self, image, mask_total):
-        inpainted_image = cv2.inpaint(image.copy(), mask_total, 10, cv2.INPAINT_TELEA)
+        # inpainted_image = cv2.inpaint(image.copy(), mask_total, 10, cv2.INPAINT_TELEA)
+        print(mask_total.shape)  # (1893, 1577) with 0 or 255
+        # print(image.shape)  # (1893, 1577, 3)
+
+        inpainted_image = image.copy()
+        inpainted_image[mask_total == 255] = [255, 255, 255]
         final_image = cv2.convertScaleAbs(inpainted_image, alpha=1.5, beta=10)
         # cv2.imwrite('test_images/inpainted_init.png', inpainted_image)
         # cv2.imwrite('test_images/inpainted_final.png', final_image)

--- a/app/AIProcessor.py
+++ b/app/AIProcessor.py
@@ -73,7 +73,8 @@ class AIProcessor:
         filtered_points, filtered_labels = self.remove_points_in_bboxes(user_points, user_labels, bbox)
         logging.info(f'2차 마스킹 - 사용자 입력 필터링: from {len(user_points)}개 to {len(filtered_points)}개')
 
-        results = self.sam_model.predict(source=image, points=filtered_points, labels=filtered_labels)
+        # results = self.sam_model.predict(source=image, points=filtered_points, labels=filtered_labels)
+        results = self.sam_model.predict(source=image, bboxes=[user_points])
         mask_points = results[0].masks.data
 
         masks_np = np.zeros(mask_points.shape[-2:], dtype=np.uint8)
@@ -82,7 +83,6 @@ class AIProcessor:
             mask_np = mask_np.squeeze()
             masks_np = cv2.bitwise_or(masks_np, mask_np)
 
-        # mask_points_uint8 = (masks_points[0] * 255).astype(np.uint8)
         # cv2.imwrite(save_path, mask_points_uint8)
         logging.info(f'2차 마스킹 - 사용자 입력에 대해 {len(mask_points)}개 영역으로 세그먼트 완료.')
         return masks_np

--- a/app/AIProcessor.py
+++ b/app/AIProcessor.py
@@ -1,0 +1,142 @@
+import torch
+import torchvision
+import numpy as np
+import cv2
+from ultralytics import YOLO
+from segment_anything import sam_model_registry, SamPredictor
+import io
+import logging
+
+
+class AIProcessor:
+    def __init__(self, yolo_path: str, sam_path: str, device: torch.device = torch.device("cpu")):
+        self.yolo_path = yolo_path
+        self.sam_path = sam_path
+        self.device = device
+        self.yolo_model = YOLO(self.yolo_path)  # yolo 로드
+        self.sam_model = None
+        self.predictor = None
+
+        self.alpha_channel = None
+        self.size = 0
+        self.height = 0
+        self.width = 0
+
+    def remove_alpha(self, image):
+        self.height, self.width = image.shape[:2]
+        self.size = self.height * self.width
+        if image.shape[2] == 4:  # RGBA or RGB
+            self.alpha_channel = image[:, :, 3]
+            image_rgb = image[:, :, :3]
+        else:
+            image_rgb = image
+
+        return image_rgb
+
+    def load_sam_model(self, model_type="vit_h"):  # sam 로드
+        self.sam_model = sam_model_registry[model_type](checkpoint=self.sam_path)
+        self.sam_model.to(self.device)
+        self.predictor = SamPredictor(self.sam_model)
+
+    def object_detection(self, img):
+        results = self.yolo_model.predict(source=img, imgsz=640, device=self.device,
+                                          iou=0.3, conf=0.3)
+        bbox = results[0].boxes.xyxy.tolist()
+        logging.info(f'1차 마스킹 - 바운딩 박스 생성 완료, {len(bbox)}개')
+        return bbox
+
+    def segment_from_points(self, user_points, user_labels, save_path=None):
+        input_point = np.array(user_points)
+        input_label = np.array(user_labels)
+
+        masks_points, scores, logits = self.predictor.predict(
+            point_coords=input_point,
+            point_labels=input_label,
+            multimask_output=False,
+        )
+
+        mask_points_uint8 = (masks_points[0] * 255).astype(np.uint8)
+        # cv2.imwrite(save_path, mask_points_uint8)
+        logging.info('2차 마스킹 - 사용자 입력 점 세그먼트 완료.')
+        return mask_points_uint8
+
+    def segment_from_boxes(self, image, bbox, save_path=None):
+        input_boxes = torch.tensor(bbox, device=self.predictor.device)
+        transformed_boxes = self.predictor.transform.apply_boxes_torch(input_boxes, image.shape[:2])
+        masks, _, _ = self.predictor.predict_torch(
+            point_coords=None,
+            point_labels=None,
+            boxes=transformed_boxes,
+            multimask_output=False,
+        )
+        masks_np = np.zeros(masks.shape[-2:], dtype=np.uint8)
+        for mask in masks:
+            mask_np = mask.cpu().numpy().astype(np.uint8) * 255
+            mask_np = mask_np.squeeze()
+            masks_np = cv2.bitwise_or(masks_np, mask_np)
+
+        # cv2.imwrite(save_path, masks_np)
+        logging.info('1차 마스킹 - 바운딩 박스 세그먼트 완료.')
+        return masks_np
+
+    def inpainting(self, image, mask_total):
+        inpainted_image = cv2.inpaint(image.copy(), mask_total, 10, cv2.INPAINT_TELEA)
+        final_image = cv2.convertScaleAbs(inpainted_image, alpha=1.5, beta=10)
+        # cv2.imwrite('test_images/inpainted_init.png', inpainted_image)
+        # cv2.imwrite('test_images/inpainted_final.png', final_image)
+        logging.info('인페인팅 및 후보정 완료.')
+
+        return final_image
+
+    def combine_alpha(self, image_rgb):
+        if self.alpha_channel is not None:  # RGBA
+            image_rgba = cv2.merge([image_rgb, self.alpha_channel])
+            return image_rgba
+        else:
+            return image_rgb
+
+    def process(self, img_bytes, user_points, user_labels, extension='jpg'):
+        """ local test 용도 Vs. server test 용도 구분 """
+        ### local 용도
+        # img_path = img_bytes
+        # image = cv2.imread(img_path, cv2.IMREAD_COLOR)
+
+        ### server 용도
+        buffer = np.frombuffer(img_bytes, dtype=np.uint8)
+        image = cv2.imdecode(buffer, cv2.IMREAD_UNCHANGED)
+
+        ### ready
+        self.load_sam_model()
+        self.predictor.set_image(image)
+        masks_total = np.zeros(image.shape[:2], dtype=np.uint8)
+
+        ### 1차: Object Detection & Segment by Box
+        bbox = self.object_detection(image)
+        if len(bbox) > 0:
+            masks_by_box = self.segment_from_boxes(image, bbox, save_path=None) # 'test_images/seg_box.png'
+            masks_total = cv2.bitwise_or(masks_total, masks_by_box)
+            logging.info(
+                f"1차 마스킹 후 shape 점검: YOLOv11 감지된 영역 shape: {masks_by_box.shape}, 이미지 영역 shape: {image.shape}")  # (1893, 1577, 3)  (1893, 1577)
+
+        ### 2차: points arguments by User & Segment by Points
+        if len(user_points) > 0:
+            mask_by_point = self.segment_from_points(user_points, user_labels, save_path=None)  # save_path='test_images/seg_points.png'
+            masks_total = cv2.bitwise_or(masks_total, mask_by_point)
+        # cv2.imwrite('test_images/mask_total.png', masks_total)
+        if isinstance(masks_total, np.ndarray):
+            image_output = self.inpainting(image, masks_total)
+            logging.info('최종 마스킹 이미지 생성 완료')
+        else:
+            image_output = image
+            logging.info('최종 마스킹이 없거나, numpy 형식의 배열이 아님.')
+
+        # image_input = self.combine_alpha(image_rgb)
+        # image_output = self.combine_alpha(image_output)
+        _, input_bytes = cv2.imencode("." + extension, image)
+        _, mask_bytes = cv2.imencode("." + extension, masks_total.astype(np.uint8))
+        _, result_bytes = cv2.imencode("." + extension, image_output)
+
+        # return 0, 0, 0
+        return io.BytesIO(input_bytes), io.BytesIO(mask_bytes), io.BytesIO(result_bytes)
+
+

--- a/app/AIProcessor.py
+++ b/app/AIProcessor.py
@@ -58,7 +58,6 @@ class AIProcessor:
         results = self.yolo_model.predict(source=img, imgsz=640, device=self.device,
                                           iou=0.3, conf=0.3)
         bbox = results[0].boxes.xyxy.tolist()
-        logging.info(f'1차 마스킹 - 바운딩 박스 생성 완료, {len(bbox)}개')
         return bbox
 
     def segment_from_points(self, image, user_points, user_labels, bbox,  save_path=None):
@@ -70,8 +69,8 @@ class AIProcessor:
             point_labels=input_label,
             multimask_output=False,
         )'''
-        filtered_points, filtered_labels = self.remove_points_in_bboxes(user_points, user_labels, bbox)
-        logging.info(f'2차 마스킹 - 사용자 입력 필터링: from {len(user_points)}개 to {len(filtered_points)}개')
+        # filtered_points, filtered_labels = self.remove_points_in_bboxes(user_points, user_labels, bbox)
+        # logging.info(f'2차 마스킹 - 사용자 입력 필터링: from {len(user_points)}개 to {len(filtered_points)}개')
 
         # results = self.sam_model.predict(source=image, points=filtered_points, labels=filtered_labels)
         results = self.sam_model.predict(source=image, bboxes=[user_points])

--- a/app/AIProcessor.py
+++ b/app/AIProcessor.py
@@ -22,6 +22,21 @@ class AIProcessor:
         self.height = 0
         self.width = 0
 
+    def remove_points_in_bboxes(point_list, label_list, bbox_list):
+        def is_point_in_bbox(p, b):
+            x, y = p
+            x_min, y_min, x_max, y_max = b
+            return x_min <= x <= x_max and y_min <= y <= y_max
+
+        filtered_p = []
+        filtered_l = []
+        for p, l in zip(point_list, label_list):
+            if not any(is_point_in_bbox(p, b) for b in bbox_list):
+                filtered_p.append(p)
+                filtered_l.append(l)
+
+        return filtered_p, filtered_l
+
     def remove_alpha(self, image):
         self.height, self.width = image.shape[:2]
         self.size = self.height * self.width

--- a/app/main.py
+++ b/app/main.py
@@ -131,8 +131,10 @@ async def processShape(request: Request):
         upload_image_to_s3(img_input_bytes, paths["input_path"])
         upload_image_to_s3(img_mask_bytes, paths["mask_path"])
         upload_image_to_s3(img_output_bytes, paths["output_path"])
-        upload_image_to_s3(one, paths["one"])
-        upload_image_to_s3(two, paths["two"])
+        if one is not None:
+            upload_image_to_s3(one, paths["one"])
+        if two is not None:
+            upload_image_to_s3(two, paths["two"])
 
         logger.info("AI 필기 제거 결과 이미지 업로드 완료")
         return JSONResponse(content={"message": "File processed successfully", "path": paths})

--- a/app/main.py
+++ b/app/main.py
@@ -66,7 +66,7 @@ def upload_image_to_s3(file_bytes, file_path):
     s3_client.upload_fileobj(file_bytes, BUCKET_NAME, file_path)
 
 
-def download_model_from_s3(yolo_path: str = 'models/yolo11_best.pt', sam_path: str = 'models/sam_vit_h_4b8939.pth'):
+def download_model_from_s3(yolo_path: str = 'models/yolo11_best.pt', sam_path: str = "models/mobile_sam.pt"):  # models/sam_vit_h_4b8939.pth
     dest_dir = f'../'  # 모델을 저장할 컨테이너 내 경로
     try:
         yolo_full_path = dest_dir+yolo_path
@@ -81,7 +81,6 @@ def download_model_from_s3(yolo_path: str = 'models/yolo11_best.pt', sam_path: s
             logger.info(f'SAM models downloaded successfully to {dest_dir}')
         else:
             logger.info(f'SAM models already exists at {dest_dir}')
-
 
         logger.info(f"Files in 'models' Dir: {os.listdir(dest_dir)}")
     except Exception as e:

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,8 @@ def create_file_path(obj_path, extension):
     paths = {"input_path": f"{dir_path}/{file_id}.input.{extension}",
              "mask_path": f"{dir_path}/{file_id}.mask.{extension}",
              "output_path": f"{dir_path}/{file_id}.output.{extension}",
+             "one": f"{dir_path}/{file_id}.mask_b.{extension}",
+             "two": f"{dir_path}/{file_id}.mask_p.{extension}",
              "extension": extension}
     return paths
 
@@ -119,9 +121,9 @@ async def processShape(request: Request):
         corrected_img_bytes = ImageManager.correct_rotation(img_bytes, paths['extension'])
         logger.info(f"시용자 입력 이미지({s3_key}) 다운로드 및 전처리 완료")
 
-        # aiProcessor = AIProcessor(yolo_path="./models/yolo11_best.pt", sam_path="./models/sam_vit_h_4b8939.pth")  # local
+        # aiProcessor = AIProcessor(yolo_path='/Users/semin/models/yolo11_best.pt', sam_path='/Users/semin/models/mobile_sam.pt')  # local
         aiProcessor = AIProcessor(yolo_path="../models/yolo11_best.pt", sam_path="../models/mobile_sam.pt")  # server
-        img_input_bytes, img_mask_bytes, img_output_bytes = aiProcessor.process(img_bytes=corrected_img_bytes,
+        img_input_bytes, img_mask_bytes, img_output_bytes, one, two = aiProcessor.process(img_bytes=corrected_img_bytes,
                                                                                 user_points=point_list,
                                                                                 user_labels=label_list)
         logger.info("AI 필기 제거 프로세스 완료")
@@ -129,6 +131,8 @@ async def processShape(request: Request):
         upload_image_to_s3(img_input_bytes, paths["input_path"])
         upload_image_to_s3(img_mask_bytes, paths["mask_path"])
         upload_image_to_s3(img_output_bytes, paths["output_path"])
+        upload_image_to_s3(one, paths["one"])
+        upload_image_to_s3(two, paths["two"])
 
         logger.info("AI 필기 제거 결과 이미지 업로드 완료")
         return JSONResponse(content={"message": "File processed successfully", "path": paths})

--- a/app/main.py
+++ b/app/main.py
@@ -120,7 +120,7 @@ async def processShape(request: Request):
         logger.info(f"시용자 입력 이미지({s3_key}) 다운로드 및 전처리 완료")
 
         # aiProcessor = AIProcessor(yolo_path="./models/yolo11_best.pt", sam_path="./models/sam_vit_h_4b8939.pth")  # local
-        aiProcessor = AIProcessor(yolo_path="../models/yolo11_best.pt", sam_path="../models/sam_vit_h_4b8939.pth")  # server
+        aiProcessor = AIProcessor(yolo_path="../models/yolo11_best.pt", sam_path="../models/mobile_sam.pt")  # server
         img_input_bytes, img_mask_bytes, img_output_bytes = aiProcessor.process(img_bytes=corrected_img_bytes,
                                                                                 user_points=point_list,
                                                                                 user_labels=label_list)

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException, File, UploadFile, Request
 from starlette import status
 from starlette.responses import StreamingResponse, JSONResponse
 from ColorRemover import ColorRemover
+from AIProcessor import AIProcessor
 import ImageFunctions as ImageManager
 import logging
 import os
@@ -36,7 +37,7 @@ except Exception as e:
 
 
 def create_file_path(obj_path, extension):
-    file_id = uuid4()  # 각 클라이언트마다 고유한 파일 ID 생성
+    file_id = uuid4()[:4]  # 각 클라이언트마다 고유한 파일 ID 생성
     dir_path = obj_path.rsplit('/', 1)[0]
     paths = {"input_path": f"{dir_path}/{file_id}.input.{extension}",
              "output_path": f"{dir_path}/{file_id}.output.{extension}",

--- a/app/main.py
+++ b/app/main.py
@@ -40,8 +40,8 @@ def create_file_path(obj_path, extension):
     file_id = uuid4()[:4]  # 각 클라이언트마다 고유한 파일 ID 생성
     dir_path = obj_path.rsplit('/', 1)[0]
     paths = {"input_path": f"{dir_path}/{file_id}.input.{extension}",
-             "output_path": f"{dir_path}/{file_id}.output.{extension}",
              "mask_path": f"{dir_path}/{file_id}.mask.{extension}",
+             "output_path": f"{dir_path}/{file_id}.output.{extension}",
              "extension": extension}
     return paths
 
@@ -517,8 +517,8 @@ async def retrieve(problem_text: str):
 async def augment(curriculum_context, query):
     prompt = ("너는 고등학생의 오답 문제를 통해 약점을 보완해주는 공책이야. \
               교육과정을 참고해서 오답 문제 핵심 의도를 바탕으로 문제에서 헷갈릴만한 요소, \
-              학생이 놓친 것 같은 중요한 개념을 찾아 그 개념에 대해 4줄 이내로 설명해주고, \
-              그 개념을 적용해서 풀이를 요점에 따라서 짧게(4줄 내외) 작성해줘. \
+              이 문제를 틀렸다면 놓칠 것 같은 같은 중요한 개념을 연관지어 그 개념에 대해 4줄 이내로 설명해주고, \
+              그 개념을 적용해서 풀이를 핵심적 원리에 집중하여 짧게(4줄 내외) 작성해줘. \
               만약 오답 문제와 교과과정이 관련이 없다고 판단되면, 교육과정은 참고하지 않으면 돼. \n\n\n")
     passage = f"오답 문제 : {query} \n\n\n"
     context = f"교과과정 : {curriculum_context} \n\n\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,8 @@ requests==2.32.3
 charset-normalizer==3.3.2
 openai==1.46.0
 pymilvus==2.4.6
+torch==2.5.1
+torchvision==0.20.1
+matplotlib==3.9.1.post1
+ultralytics==8.3.31
+git+https://github.com/facebookresearch/segment-anything.git@dca509fe793f601edb92606367a655c15ac00fdf


### PR DESCRIPTION
### PR 타입
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 파일/폴더 수정/삭제
- [x] 코드 리팩토링
- [x] 주석 추가/수정
<br>

### 반영 브랜치
dev ➡️ main
<br>

### 작업 사항
#### 📝`AI 필기제거 API 개발`
기존엔 POST요청과 process-color 엔드포인트였으며 색상기반으로 필기를 인식. 이는 그대로 두었으며 AI기반 필기인식 API인 process-shape 엔드포인트로 POST 요청 가능.
이미지 URL을 받아 다운로드, 전처리 및 필기제거 및 후처리 후, 입력, 중간, 중간1, 중간2, 결과 이미지를 모두 s3에 업로드.
#### 📝`AI 필기제거 로직 개발 및 경량화`
AI 필기제거에 파인튜닝한 객체탐지모델(YOLOv11)과 파운데이션 세그멘테이션 모델(SAM-vit-h)을 활용했으나, 세그멘테이션 모델의 용량 및 연산 처리 속도가 1분이상이라 비현실적임을 감안하여, 모바일용도의 가벼운 경량화 모델로 변경하여 연산 처리 시간을 50% 이상 감축하는 데 성공.
#### 📝`도커파일 & 패키지 버전 파일 수정`
모델을 서버 도커 컨테이너 내 보관 및 디렉토리 생성이 필요해짐에 따라 도커파일의 RUN 명령어를 수정.
SAM을 위한 git 설치도 이루어지기 위해, 그리고 추가적으로 필요한 ML 패키지 설치를 위해 requirements.txt를 추가
#### 📝`기타 버그 수정`
요청에 필드가 오지 않는 경우, 마스킹 중간 결과가 없는 경우 등을 고려하여 예외처리를 진행.
또한 동그란 마킹을 인식할 경우 후보정에서 모폴로지 변환을 통해서 원 내부를 제외.
<br>

### 테스트 방법
추가된 기능은 아래 방식으로 자유롭게 요청&응답 테스트가 가능합니다.
- Dev/Prod 서버 Postman
- Dev/Prod 서버 Swagger UI
 process-shape에 POST요청을 보내면 되며 형식은 아래와 같습니다.
<code>{
    "fullUrl": 이미지 URL,
    "points": [200,800,1400,2000],
    "labels": []
}</code>

### 테스트 결과
|입력|마스킹|결과|
|:--:|:--:|:--:|
|![image](https://github.com/user-attachments/assets/0f7c56a0-59bd-4878-92b6-edb608ac25ce)|![image](https://github.com/user-attachments/assets/90ae1773-b747-42d8-abf3-71f997d6ed8a)|![image](https://github.com/user-attachments/assets/b1400d6c-6867-42bd-b3ac-ce40cc2d8dfd)|